### PR TITLE
correct README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ the tags. So with:
 
 	"Hello world!"
 
-... after selecting the string, then pressing `sf`, entering `print`
+... after selecting the string, then pressing `Sf`, entering `print`
 and pressing return you would get
 
     print("Hello world!")


### PR DESCRIPTION
To add surround to a function, S should be used but not s.