### PR TITLE
Fix indentation of surrounded lines

### DIFF
--- a/evil-surround.el
+++ b/evil-surround.el
@@ -294,8 +294,8 @@ Becomes this:
 
                   ((eq type 'line)
                    (insert open)
-                   (indent-according-to-mode)
                    (newline-and-indent)
+                   (indent-region beg end)
                    (goto-char (overlay-end overlay))
                    (insert close)
                    (indent-according-to-mode)


### PR DESCRIPTION
When surrounding a set of lines (using a command like `Vjjs{` in
cc-mode, for example), only the first line was correctly indented. This
commit fixes evil-surround-region so that all the selected lines are
properly indented after being surrounded.