### PR TITLE
Refactor evil-surround-block

### DIFF
--- a/evil-surround.el
+++ b/evil-surround.el
@@ -217,21 +217,19 @@ overlays OUTER and INNER, which are passed to `evil-surround-delete'."
   (define-key evil-operator-shortcut-map "s" 'evil-surround-line)
   (define-key evil-operator-shortcut-map "S" 'evil-surround-line))
 
+(defun evil-surround-column-at (pos)
+  (save-excursion (goto-char pos) (current-column)))
+
 (defun evil-surround-block (beg end char)
-  "Split a block into regions per line and surround each of them individually."
-  (save-excursion
-    (goto-char beg)
-    (let ((lines (- (1+ (line-number-at-pos end)) (line-number-at-pos beg)))
-          (start-col (current-column))
-          (end-col (save-excursion (goto-char end) (current-column))))
-      (while (> lines 0)
-        (move-to-column start-col)
-        ;; skip lines that are empty at this column
-        (unless (/= start-col (current-column))
-          (evil-surround-region (point) (save-excursion (move-to-column end-col) (point))
-                                'inclusive char))
-        (setq lines (1- lines))
-        (next-line)))))
+  "Split a block into regions per line and surround them individually. Skips
+lines where the columns don't line up."
+  (let* ((beg-col (evil-surround-column-at beg))
+         (end-col (evil-surround-column-at end)))
+    (evil-apply-on-block
+     (lambda (ibeg iend)
+       (unless (< (evil-surround-column-at ibeg) (min beg-col end-col))
+         (evil-surround-region ibeg iend t char)))
+     beg end nil)))
 
 ;; Dispatcher function in Operator-Pending state.
 ;; "cs" calls `evil-surround-change', "ds" calls `evil-surround-delete',

--- a/evil-surround.el
+++ b/evil-surround.el
@@ -223,8 +223,8 @@ overlays OUTER and INNER, which are passed to `evil-surround-delete'."
 (defun evil-surround-block (beg end char)
   "Split a block into regions per line and surround them individually. Skips
 lines where the columns don't line up."
-  (let* ((beg-col (evil-surround-column-at beg))
-         (end-col (evil-surround-column-at end)))
+  (let ((beg-col (evil-surround-column-at beg))
+        (end-col (evil-surround-column-at end)))
     (evil-apply-on-block
      (lambda (ibeg iend)
        (unless (< (evil-surround-column-at ibeg) (min beg-col end-col))

--- a/evil-surround.el
+++ b/evil-surround.el
@@ -221,8 +221,9 @@ overlays OUTER and INNER, which are passed to `evil-surround-delete'."
   (save-excursion (goto-char pos) (current-column)))
 
 (defun evil-surround-block (beg end char)
-  "Split a block into regions per line and surround them individually. Skips
-lines where the columns don't line up."
+  "Surrounds a block selection with a character, as if `evil-surround-region'
+were called on each segment in each line. This skips lines where EOL < BEG's
+column."
   (let ((beg-col (evil-surround-column-at beg))
         (end-col (evil-surround-column-at end)))
     (evil-apply-on-block


### PR DESCRIPTION
Not a crucial edit, but I stumbled upon `evil-apply-on-block` and thought `evil-surround-block` would be much simpler with it. I've ensured it maintains parity with vim-surround, and works at least as well as the old function.

EDIT: Turns out this refactor fixes a couple edge cases with column-surrounding to EOL.