### PR TITLE
Fix repetitive prompts with function pairs in block surrounds

### DIFF
--- a/evil-surround.el
+++ b/evil-surround.el
@@ -284,7 +284,7 @@ Becomes this:
   (interactive "<R>c")
   (when (evil-surround-valid-char-p char)
     (let* ((overlay (make-overlay beg end nil nil t))
-           (pair (evil-surround-pair char))
+           (pair (or (and (boundp 'pair) pair) (evil-surround-pair char)))
            (open (car pair))
            (close (cdr pair)))
       (unwind-protect


### PR DESCRIPTION
When performing a block surround with a pair that is defined as a function (such as `(?< . evil-surround-read-tag)`) evil-surround will prompt the user for the tag on every line. This patch fixes that.

