### PR TITLE
Fix #52, #39, and #5 (linewise surrounding)

### DIFF
--- a/evil-surround.el
+++ b/evil-surround.el
@@ -314,12 +314,12 @@ Becomes this:
 
                   (force-new-line
                    (insert open)
-                   (indent-according-to-mode)
                    (newline-and-indent)
-                   (goto-char (overlay-end overlay))
-                   (newline-and-indent)
-                   (insert close)
-                   (indent-region beg-pos (point)))
+                   (let ((pt (point)))
+                     (goto-char (overlay-end overlay))
+                     (newline-and-indent)
+                     (insert close)
+                     (indent-region pt (point))))
 
                   (t
                    (insert open)


### PR DESCRIPTION
Linewise surrounds now behave more like vim-surround:

1. Leading (and trailing) whitespace are ignored
2. Indentation is unchanged if performed on a single line
3. Multiline surrounds are reindented
4. Point is left at overlay-start rather than overlay-end after surround

My rudimentary tests pass, but I'd appreciate if anyone would help test this some more!