### PR TITLE
Visual linewise surround fix (Fix #71)

### DIFF
--- a/evil-surround.el
+++ b/evil-surround.el
@@ -299,10 +299,8 @@ Becomes this:
                          (or force-new-line
                              ;; Force newline if not invoked from an operator, e.g. VS)
                              (eq evil-this-operator 'evil-surround-region)
-                             ;; Or on multi-line yanks (but not on single-line yanks),
-                             ;; e.g. ysj)
-                             (and (eq evil-this-operator 'evil-yank)
-                                  (/= (line-number-at-pos) (line-number-at-pos (1- end))))))
+                             ;; Or on multi-line operator surrounds (like 'ysj]')
+                             (/= (line-number-at-pos) (line-number-at-pos (1- end)))))
 
                    (back-to-indentation)
                    (setq beg-pos (point))

--- a/evil-surround.el
+++ b/evil-surround.el
@@ -295,6 +295,15 @@ Becomes this:
                    (evil-surround-block beg end char))
 
                   ((eq type 'line)
+                   (setq force-new-line
+                         (or force-new-line
+                             ;; Force newline if not invoked from an operator, e.g. VS)
+                             (eq evil-this-operator 'evil-surround-region)
+                             ;; Or on multi-line yanks (but not on single-line yanks),
+                             ;; e.g. ysj)
+                             (and (eq evil-this-operator 'evil-yank)
+                                  (/= (line-number-at-pos) (line-number-at-pos (1- end))))))
+
                    (back-to-indentation)
                    (setq beg-pos (point))
                    (insert open)


### PR DESCRIPTION
See #71. Side-note: this fix improves parity with vim-surround.