### PR TITLE
Escape a backtick in markdown and fix the keywords on MELPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ inserting angle brackets is, so you can add this:
 Don't worry about having two entries for `<` surround will take the first.
 
 Or in Emacs Lisp modes using \` to enter \` ' is quite useful, but not adding a
-pair of ` (the default behavior if no entry in `evil-surround-pairs-alist` is
+pair of \` (the default behavior if no entry in `evil-surround-pairs-alist` is
 present), so you can do this:
 
     (add-hook 'emacs-lisp-mode-hook (lambda ()

--- a/evil-surround.el
+++ b/evil-surround.el
@@ -11,11 +11,11 @@
 ;; Created: July 23 2011
 ;; Version: 0.1
 ;; Package-Requires: ((evil "1.2.12"))
-;; Keywords: emulation, vi, evil
 ;; Mailing list: <implementations-list at lists.ourproject.org>
 ;;      Subscribe: http://tinyurl.com/implementations-list
 ;;      Newsgroup: nntp://news.gmane.org/gmane.emacs.vim-emulation
 ;;      Archives: http://dir.gmane.org/gmane.emacs.vim-emulation
+;; Keywords: emulation, vi, evil
 ;;
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
The commit messages include more detail.