### PR TITLE
Point to new repository for Evil

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To enable it globally, add the following lines to ~/.emacs:
 Alternatively, you can enable surround-mode along a major mode by adding
 `turn-on-surround-mode' to the mode hook.
 
-This package uses [Evil](https://gitorious.org/evil) as its vi layer.
+This package uses [Evil](https://bitbucket.org/lyro/evil/) as its vi layer.
 
 ## Add surrounding ##
 You can surround in visual-state with `S<textobject>` or `gS<textobject>`.

--- a/evil-surround.el
+++ b/evil-surround.el
@@ -33,7 +33,7 @@
 ;;
 ;; This package uses Evil as its vi layer. It is available from:
 ;;
-;;     http://gitorious.org/evil
+;;     https://bitbucket.org/lyro/evil/
 
 ;;; Code:
 


### PR DESCRIPTION
Evil is no longer hosted on Gitorious. This repository is apparently the
new official repository for Evil, since it is hosted under Frank
Fischer’s account, and Evil’s page on the Emacs wiki[1] points to the
wiki of this repository as being Evil’s home page.

[1] https://www.emacswiki.org/emacs/Evil