### PR TITLE
Fix defcustom type specification for pairs-alist variable

### DIFF
--- a/evil-surround.el
+++ b/evil-surround.el
@@ -65,8 +65,11 @@ Each item is of the form (TRIGGER . (LEFT . RIGHT)), all strings.
 Alternatively, a function can be put in place of (LEFT . RIGHT).
 This only affects inserting pairs, not deleting or changing them."
   :group 'surround
-  :type '(repeat (cons (regexp :tag "Key")
-                       (symbol :tag "Surround pair"))))
+  :type '(alist
+          :key-type (character :tag "Key")
+          :value-type (choice
+                       (cons (string :tag "Opening") (string :tag "Closing"))
+                       (function :tag "Function"))))
 (make-variable-buffer-local 'evil-surround-pairs-alist)
 
 (defcustom evil-surround-operator-alist


### PR DESCRIPTION
this fixes the `:type` specification for `evil-surround-pairs-alist` so that the customize interface can do something sensible with it. (partial) screenshot after applying this fix:

![image](https://cloud.githubusercontent.com/assets/748944/20020329/0ff0f77e-a2d1-11e6-8711-d4dfc7f5a617.png)
