### PR TITLE
fix #84: dot operator works again. reverts 66b8f89 which reintroduced #24 as a regression

### DIFF
--- a/evil-surround.el
+++ b/evil-surround.el
@@ -166,14 +166,14 @@ See also `evil-surround-outer-overlay'."
       (evil-expand-range range)
       range)))
 
-;;;###autoload (autoload 'evil-surround-delete "evil-surround" nil t)
-(evil-define-command evil-surround-delete (char &optional outer inner)
+;;;###autoload
+(defun evil-surround-delete (char &optional outer inner)
   "Delete the surrounding delimiters represented by CHAR.
 Alternatively, the text to delete can be represented with
 the overlays OUTER and INNER, where OUTER includes the delimiters
 and INNER excludes them. The intersection (i.e., difference)
 between these overlays is what is deleted."
-  (interactive "<C>")
+  (interactive "c")
   (cond
    ((and outer inner)
     (delete-region (overlay-start outer) (overlay-start inner))
@@ -190,16 +190,16 @@ between these overlays is what is deleted."
         (when outer (delete-overlay outer))
         (when inner (delete-overlay inner)))))))
 
-;;;###autoload (autoload 'evil-surround-change "evil-surround" nil t)
-(evil-define-command evil-surround-change (char &optional outer inner)
+;;;###autoload
+(defun evil-surround-change (char &optional outer inner)
   "Change the surrounding delimiters represented by CHAR.
 Alternatively, the text to delete can be represented with the
 overlays OUTER and INNER, which are passed to `evil-surround-delete'."
-  (interactive "<C>")
+  (interactive "c")
   (cond
    ((and outer inner)
     (evil-surround-delete char outer inner)
-    (let ((key (evil-read-key)))
+    (let ((key (read-char)))
       (evil-surround-region (overlay-start outer)
                             (overlay-end outer)
                             nil (if (evil-surround-valid-char-p key) key char))))
@@ -292,7 +292,7 @@ Becomes this:
      :thing
    }"
 
-  (interactive "<R><C>")
+  (interactive "<R>c")
   (when (evil-surround-valid-char-p char)
     (let* ((overlay (make-overlay beg end nil nil t))
            (pair (or (and (boundp 'pair) pair) (evil-surround-pair char)))
@@ -348,7 +348,7 @@ Becomes this:
 
 (evil-define-operator evil-Surround-region (beg end type char)
   "Call surround-region, toggling force-new-line"
-  (interactive "<R><C>")
+  (interactive "<R>c")
   (evil-surround-region beg end type char t))
 
 ;;;###autoload


### PR DESCRIPTION
this fixes #84, which is a replay of #24, brought back thanks to commit #66b8f89

could the maintainer review? thanks.